### PR TITLE
Fix error import of subSources

### DIFF
--- a/lib/helpers/methods.js
+++ b/lib/helpers/methods.js
@@ -1,0 +1,13 @@
+'use babel'
+// helper function for combining sources
+import path from 'path';
+
+function mapSourceDir(dir,file){
+	return path.isAbsolute(file)
+	? dir
+	: path.dirname(
+        path.normalize(dir + '/' + file)
+    );
+}
+
+export default mapSourceDir;

--- a/lib/vm/vm.js
+++ b/lib/vm/vm.js
@@ -9,6 +9,7 @@ import fs from 'fs'
 import Solc from 'solc'
 import Trie from 'merkle-patricia-tree'
 import VmHelpers from './methods'
+import mapSourceDir from '../helpers/methods'
 
 let View;
 View = require('./view');
@@ -177,7 +178,7 @@ class VMEnv {
 			}
 			imports[fn] = 1;
 			subSource = fs.readFileSync(dir + "/" + fn, o);
-			match.source = this.combineSource(dir, subSource, imports);
+			match.source = this.combineSource(mapSourceDir(dir,fn), subSource, imports);
 			source = source.replace(iline, match.source);
 		}
 		return source;

--- a/lib/web3/web3.js
+++ b/lib/web3/web3.js
@@ -8,6 +8,7 @@ import path from 'path'
 import fs from 'fs'
 import Web3 from 'web3'
 import Web3Helpers from './methods'
+import mapSourceDir from '../helpers/methods'
 
 let View, helpers;
 View = require('./view');
@@ -199,7 +200,7 @@ class Web3Env {
 			}
 			imports[fn] = 1;
 			subSource = fs.readFileSync(dir + "/" + fn, o);
-			match.source = this.combineSource(dir, subSource, imports);
+			match.source = this.combineSource(mapSourceDir(dir,fn), subSource, imports);
 			source = source.replace(iline, match.source);
 		}
 		return source;


### PR DESCRIPTION
Fix compiler not being able to resolve relative path of subsources when source is not in root directory.

Example: 
* /contracts/Contract.sol -> import '../node_modules/zeppelin-solidity/contracts/token/MintableToken.sol';
* (...)MintableToken.sol -> import './StandardToken.sol'; -> StandardToken not resolved