### PR TITLE
Add support for import from npm packages

### DIFF
--- a/lib/helpers/compiler-imports.js
+++ b/lib/helpers/compiler-imports.js
@@ -39,13 +39,42 @@ async function handleGithubCall(fullpath, repoPath, path, filename, fileRoot) {
         }
     });
 }
-async function handleLocalImport(pathString, filename, fileRoot) {
+async function handleNodeModulesImport(pathString, filename, fileRoot){
     const o = { encoding: 'UTF-8' };
-    const p = pathString ? path.resolve(fileRoot, pathString, filename) : path.resolve(fileRoot, filename);
-    const content = fs.readFileSync(p, o);
-    fileRoot = pathString ? path.resolve(fileRoot, pathString) : fileRoot;
-    const response = { filename, content, fileRoot };
-    return response;
+    var modulesDir = fileRoot;
+
+    while(true){
+      var p = path.join(modulesDir, "node_modules", pathString, filename);
+      try {
+        const content = fs.readFileSync(p, o);
+        fileRoot = path.join(modulesDir, "node_modules", pathString);
+        const response = { filename, content, fileRoot };
+        return response;
+      }
+      catch(err){}
+
+      // Recurse outwards until impossible
+      var oldModulesDir = modulesDir;
+      modulesDir = path.join(modulesDir, '..');
+      if (modulesDir === oldModulesDir) {
+        break;
+      }
+    }
+
+}
+async function handleLocalImport(pathString, filename, fileRoot) {
+    // if no relative/absolute path given then search in node_modules folder
+    if (pathString && pathString.indexOf(".") !== 0 && pathString.indexOf("/") !== 0) {
+      return handleNodeModulesImport(pathString, filename, fileRoot)
+    }
+    else{
+      const o = { encoding: 'UTF-8' };
+      const p = pathString ? path.resolve(fileRoot, pathString, filename) : path.resolve(fileRoot, filename);
+      const content = fs.readFileSync(p, o);
+      fileRoot = pathString ? path.resolve(fileRoot, pathString) : fileRoot;
+      const response = { filename, content, fileRoot };
+      return response;
+    }
 }
 async function getHandlers() {
     return [

--- a/lib/helpers/compiler-imports.js
+++ b/lib/helpers/compiler-imports.js
@@ -51,12 +51,12 @@ async function getHandlers() {
     return [
         {
             type: 'local',
-            match: /(^(?!(?:http:\/\/)|(?:https:\/\/)?(?:www.)?(?:github.com)))(^\/*[\w+-_/]*\/)*?(\w+.sol)/g,
+            match: /(^(?!(?:http:\/\/)|(?:https:\/\/)?(?:www.)?(?:github.com)))(^\/*[\w+-_/]*\/)*?(\w+\.sol)/g,
             handle: async(match, fileRoot) => { return await handleLocalImport(match[2], match[3], fileRoot); }
         },
         {
             type: 'github',
-            match: /^(https?:\/\/)?(www.)?github.com\/([^/]*\/[^/]*)(.*\/(\w+.sol))/g,
+            match: /^(https?:\/\/)?(www.)?github.com\/([^/]*\/[^/]*)(.*\/(\w+\.sol))/g,
             handle: async(match, fileRoot) => {
                 return await handleGithubCall(match[0], match[3], match[4], match[5], fileRoot);
             }


### PR DESCRIPTION
This feature update is w.r.t. #170 

If no absolute or relative path is provided in the `import` statement then, `etheratom` will look for the corresponding `.sol` file from within the `node_modules` directory.