### PR TITLE
Fix cannot install on windows bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     }
   },
   "scripts": {
-    "postinstall": "npm install solc; node ./formatSolc.js",
+    "postinstall": "npm install solc && node ./formatSolc.js",
     "build": "rollup -c"
   },
   "devDependencies": {


### PR DESCRIPTION
';' doesn't support in windows cmd but '&&', and linux support '&&' too