### PR TITLE
fix: multiple compilations crash

### DIFF
--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -45,17 +45,20 @@ export default class Web3Helpers {
           return /\.sol/.test(key)
         })
 
-        let hashId
+        let hashId = md5(sources[fileName].content)
 
         if (this.jobs[fileName]) {
-          hashId = md5(sources[fileName].content)
-          if (this.jobs[fileName].hashId === hashId) {
+          if (this.jobs[fileName].hashId === hashId || this.jobs[fileName].hashId === undefined) {
+            this.jobs[fileName].wasBusy = true
+            console.log(hashId)
             console.error(`Job in progress for ${fileName}`)
             return
           }
 
           this.jobs[fileName].solcWorker.kill()
           console.error(`Killing older job for ${fileName}`)
+        } else {
+          this.jobs[fileName] = { hashId }
         }
 
         // compile solidity using solcjs
@@ -76,19 +79,25 @@ export default class Web3Helpers {
             };
             const input = { language: 'Solidity', sources, settings };
             const solcWorker = this.createWorker();
-            this.jobs[fileName] = { solcWorker, hashId }
+            this.jobs[fileName].solcWorker = solcWorker
             solcWorker.send({ command: 'compile', payload: input });
 
             solcWorker.on('message', m => {
                 if(m.compiled) {
                     this.store.dispatch({ type: SET_COMPILED, payload: JSON.parse(m.compiled) });
                     this.store.dispatch({ type: SET_COMPILING, payload: false });
+                    this.jobs[fileName].successHash = hashId
                     solcWorker.kill();
                 }
             });
             solcWorker.on('error', e => console.error(e));
             solcWorker.on('exit', (code, signal) => {
-                this.store.dispatch({ type: SET_COMPILING, payload: false });
+                if (this.jobs[fileName].wasBusy && hashId !== this.jobs[fileName].successHash) {
+                  this.store.dispatch({ type: SET_COMPILING, payload: true })
+                } else {
+                  this.store.dispatch({ type: SET_COMPILING, payload: false });
+                  this.jobs[fileName] = false
+                }
                 console.log('%c Compile worker process exited with ' + `code ${code} and signal ${signal}`, 'background: rgba(36, 194, 203, 0.3); color: #EF525B');
             });
         } catch (e) {

--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -84,13 +84,11 @@ export default class Web3Helpers {
                     this.store.dispatch({ type: SET_COMPILED, payload: JSON.parse(m.compiled) });
                     this.store.dispatch({ type: SET_COMPILING, payload: false });
                     solcWorker.kill();
-                    this.jobs[fileName] = false
                 }
             });
             solcWorker.on('error', e => console.error(e));
             solcWorker.on('exit', (code, signal) => {
                 this.store.dispatch({ type: SET_COMPILING, payload: false });
-                this.jobs[fileName] = false
                 console.log('%c Compile worker process exited with ' + `code ${code} and signal ${signal}`, 'background: rgba(36, 194, 203, 0.3); color: #EF525B');
             });
         } catch (e) {

--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -18,6 +18,7 @@
 // methods.js are collection of various functions used to execute calls on web3
 
 import EventEmitter from 'events';
+import md5 from 'md5';
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import { fork } from 'child_process';
 
@@ -32,7 +33,7 @@ export default class Web3Helpers {
         this.web3 = web3;
         this.store = store;
         this.jobs = {
-          //"hash": solcWorker
+          // fileName: { solcWorker, hash }
         }
     }
     createWorker(fn) {
@@ -44,8 +45,16 @@ export default class Web3Helpers {
           return /\.sol/.test(key)
         })
 
+        let hashId
+
         if (this.jobs[fileName]) {
-          this.jobs[fileName].kill()
+          hashId = md5(sources[fileName].content)
+          if (this.jobs[fileName].hashId === hashId) {
+            console.error(`Job in progress for ${fileName}`)
+            return
+          }
+
+          this.jobs[fileName].solcWorker.kill()
           console.error(`Killing older job for ${fileName}`)
         }
 
@@ -67,7 +76,7 @@ export default class Web3Helpers {
             };
             const input = { language: 'Solidity', sources, settings };
             const solcWorker = this.createWorker();
-            this.jobs[fileName] = solcWorker
+            this.jobs[fileName] = { solcWorker, hashId }
             solcWorker.send({ command: 'compile', payload: input });
 
             solcWorker.on('message', m => {

--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -18,6 +18,7 @@
 // methods.js are collection of various functions used to execute calls on web3
 
 import EventEmitter from 'events';
+import createHash from 'crypto';
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import { fork } from 'child_process';
 
@@ -31,16 +32,32 @@ export default class Web3Helpers {
     constructor(web3, store) {
         this.web3 = web3;
         this.store = store;
-        this.jobs = []
+        this.jobs = {
+          //"hash": solcWorker
+          count: 0,
+          order: []
+        }
     }
     createWorker(fn) {
         const pkgPath = atom.packages.resolvePackagePath('etheratom');
         return fork(`${pkgPath}/lib/web3/worker.js`);
     }
     async compileWeb3(sources) {
-        if (this.jobs.length > 10) {
-            this.jobs[0].kill()
+        sources.hashId = createHash('sha256').update(JSON.stringify(sources)).digest()
+
+        if (this.jobs[sources.hashId]) {
+          console.error('job already started')
+          return
+        } else {
+          this.jobs[sources.hashId] = true
+          this.jobs.order.push(sources.hashId)
+          this.jobs.count ++
         }
+
+        if (this.jobs.count > 5) {
+            this.jobs[this.jobs.order[0]].kill()
+        }
+
         // compile solidity using solcjs
         // sources have Compiler Input JSON sources format
         // https://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description
@@ -59,7 +76,7 @@ export default class Web3Helpers {
             };
             const input = { language: 'Solidity', sources, settings };
             const solcWorker = this.createWorker();
-            this.jobs.push(solcWorker)
+            this.jobs[sources.hashId] = solcWorker
             solcWorker.send({ command: 'compile', payload: input });
 
             solcWorker.on('message', m => {

--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -31,12 +31,16 @@ export default class Web3Helpers {
     constructor(web3, store) {
         this.web3 = web3;
         this.store = store;
+        this.jobs = []
     }
     createWorker(fn) {
         const pkgPath = atom.packages.resolvePackagePath('etheratom');
         return fork(`${pkgPath}/lib/web3/worker.js`);
     }
     async compileWeb3(sources) {
+        if (this.jobs.length > 10) {
+            this.jobs[0].kill()
+        }
         // compile solidity using solcjs
         // sources have Compiler Input JSON sources format
         // https://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description
@@ -55,6 +59,7 @@ export default class Web3Helpers {
             };
             const input = { language: 'Solidity', sources, settings };
             const solcWorker = this.createWorker();
+            this.jobs.push(solcWorker)
             solcWorker.send({ command: 'compile', payload: input });
 
             solcWorker.on('message', m => {

--- a/lib/web3/methods.js
+++ b/lib/web3/methods.js
@@ -18,7 +18,6 @@
 // methods.js are collection of various functions used to execute calls on web3
 
 import EventEmitter from 'events';
-import createHash from 'crypto';
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import { fork } from 'child_process';
 
@@ -34,8 +33,6 @@ export default class Web3Helpers {
         this.store = store;
         this.jobs = {
           //"hash": solcWorker
-          count: 0,
-          order: []
         }
     }
     createWorker(fn) {
@@ -43,19 +40,13 @@ export default class Web3Helpers {
         return fork(`${pkgPath}/lib/web3/worker.js`);
     }
     async compileWeb3(sources) {
-        sources.hashId = createHash('sha256').update(JSON.stringify(sources)).digest()
+        let fileName = Object.keys(sources).find(key => {
+          return /\.sol/.test(key)
+        })
 
-        if (this.jobs[sources.hashId]) {
-          console.error('job already started')
-          return
-        } else {
-          this.jobs[sources.hashId] = true
-          this.jobs.order.push(sources.hashId)
-          this.jobs.count ++
-        }
-
-        if (this.jobs.count > 5) {
-            this.jobs[this.jobs.order[0]].kill()
+        if (this.jobs[fileName]) {
+          this.jobs[fileName].kill()
+          console.error(`Killing older job for ${fileName}`)
         }
 
         // compile solidity using solcjs
@@ -76,7 +67,7 @@ export default class Web3Helpers {
             };
             const input = { language: 'Solidity', sources, settings };
             const solcWorker = this.createWorker();
-            this.jobs[sources.hashId] = solcWorker
+            this.jobs[fileName] = solcWorker
             solcWorker.send({ command: 'compile', payload: input });
 
             solcWorker.on('message', m => {
@@ -84,11 +75,13 @@ export default class Web3Helpers {
                     this.store.dispatch({ type: SET_COMPILED, payload: JSON.parse(m.compiled) });
                     this.store.dispatch({ type: SET_COMPILING, payload: false });
                     solcWorker.kill();
+                    this.jobs[fileName] = false
                 }
             });
             solcWorker.on('error', e => console.error(e));
             solcWorker.on('exit', (code, signal) => {
                 this.store.dispatch({ type: SET_COMPILING, payload: false });
+                this.jobs[fileName] = false
                 console.log('%c Compile worker process exited with ' + `code ${code} and signal ${signal}`, 'background: rgba(36, 194, 203, 0.3); color: #EF525B');
             });
         } catch (e) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ethereumjs-util": "^6.0.0",
     "ethereumjs-vm": "2.4.0",
     "idempotent-babel-polyfill": "^7.0.0",
+    "md5": "^2.2.1",
     "merkle-patricia-tree": "^2.1.2",
     "prop-types": "^15.6.1",
     "react": "16.6.1",


### PR DESCRIPTION
The idea is very simple: allow up to 10 jobs to be in the 'queue' at once; when an 11th job is scheduled to be created, then `this.jobs[0].kill()` where every job is a `solcWorker`.

I haven't tested this, I suggest you verify and mess with the 10 max value to see if there's a sweetspot.

#198 